### PR TITLE
Add duplicate definition

### DIFF
--- a/app/controllers/definitions_controller.rb
+++ b/app/controllers/definitions_controller.rb
@@ -1,6 +1,6 @@
 class DefinitionsController < ApplicationController
-  before_action :set_definition, only: [:show, :edit, :update, :pdf]
-  before_action :set_log, only: [:show, :edit, :pdf]
+  before_action :set_definition, only: [:show, :edit, :duplicate, :update, :pdf]
+  before_action :set_log, only: [:show, :edit, :duplicate, :pdf]
 
   def show
   end
@@ -37,22 +37,11 @@ class DefinitionsController < ApplicationController
   def edit
   end
 
-  # same as create
-  def update
-    @definition = Definition.init_params(DefinitionForm.new(params))
-
-    # 指標番号や変更者などの必須要素の確認とエラーメッセージ作成
-    @error = check_necessary_params
-
-    # すでに使われている指標番号を見つける
-    @dups = @definition.find_duplicates
-
-    return if @error.present?
-    if @dups.blank?
-      @definition.save_with_log!(params[:editor], params[:message])
-    else
-      @definition.save_draft_with_log!(params[:editor], params[:message])
-    end
+  def duplicate
+    @definition.numbers = {}
+    @logs = []
+    @duplicate_flg = true
+    render :edit
   end
 
   def upload

--- a/app/forms/definition_form.rb
+++ b/app/forms/definition_form.rb
@@ -3,7 +3,7 @@ class DefinitionForm
   attr_reader :log_id, :numbers, :years, :group, :name, :meaning, :dataset, :def_summary,
               :definitions, :drug_output, :def_risks, :method, :order, :annotation,
               :standard_value, :references, :review_span, :indicator, :created_at,
-              :search_index, :soft_delete
+              :search_index, :soft_delete, :duplicate_flg
 
   def initialize(params = [])
     @params = params
@@ -28,10 +28,11 @@ class DefinitionForm
     @created_at = Time.zone.now.strftime('%Y-%m-%d')
     @search_index = search_index
     @soft_delete = false
+    @duplicate_flg = params[:duplicate_flg] == 'true'
   end
 
   def log_id
-    @params['log_id'].blank? ? Definition.all.size : @params['log_id'].to_i
+    @params['log_id'].blank? ? Definition.count : @params['log_id'].to_i
   end
 
   def numbers

--- a/app/models/definition.rb
+++ b/app/models/definition.rb
@@ -66,16 +66,21 @@ class Definition
     self.save!
   end
 
+  def update_log_id
+    self.log_id = Definition.count
+  end
+
   class << self
     def init_params(params)
       d = Definition.new
       param_list = %w(log_id numbers years group name meaning dataset def_summary
                       definitions drug_output def_risks method order annotation
                       standard_value references review_span indicator created_at
-                      search_index soft_delete)
+                      search_index soft_delete duplicate_flg)
       param_list.each do |name|
         d[name] = eval("params.#{name}")
       end
+      d.update_log_id if d.duplicate_flg
       d
     end
 

--- a/app/views/definitions/_edit_form.html.erb
+++ b/app/views/definitions/_edit_form.html.erb
@@ -5,6 +5,7 @@
   <div class="col-xs-4">
 
     <div class="form-group">
+      <h4><b>プロジェクト名</b></h4>
       <% PROJECT_NAME_KEYS.each do |prjt| %>
         <% if @definition.numbers[prjt[1]].present? %>
           <%= check_box_tag "project_#{prjt[1]}", true, true, :onChange => "showNumberForm('project_#{prjt[1]}')" %> <%= prjt[0] %>
@@ -472,6 +473,7 @@
   <div class="col-xs-4">
 
     <%= hidden_field_tag 'log_id', @definition.log_id %>
+    <%= hidden_field_tag 'duplicate_flg', @duplicate_flg %>
     <div class="form-group">
       <%= submit_tag "　作　成　", :class => "btn btn-lg btn-success" %>
     </div>

--- a/app/views/definitions/_form.html.erb
+++ b/app/views/definitions/_form.html.erb
@@ -1,6 +1,5 @@
 <%= form_tag definitions_path, multipart: true, remote: true do %>
 
-
   <div id="error"></div>
 
   <div class="col-xs-4">

--- a/app/views/definitions/show.html.erb
+++ b/app/views/definitions/show.html.erb
@@ -346,6 +346,7 @@
 </div>
 
 <%= link_to '編集', edit_definition_path %>
+<%= link_to '複製', def_duplicate_path %>
 <%= link_to 'pdf', def_pdf_path %>
 
 <script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get 'definitions/confirm/:id' => 'definitions#confirm', as: :confirm_dup
   get 'definitions/success' => 'definitions#success', as: :def_success
   get 'definitions/:id/edit' => 'definitions#edit', as: :def_edit
+  get 'definitions/:id/duplicate' => 'definitions#duplicate', as: :def_duplicate
   get 'definitions/:id/sheet' => 'definitions#pdf', as: :def_pdf
   get 'definitions/:prjt/:qid' => 'definitions#search', as: :def_search
 

--- a/spec/features/definition_spec.rb
+++ b/spec/features/definition_spec.rb
@@ -170,6 +170,55 @@ RSpec.describe DefinitionsController, type: :feature do
     expect(page).to have_content('変更者: 変更者1　 変更メッセージ: テストのために変更しました')
   end
 
+  scenario 'duplicate definition', js: true do
+    visit '/definitions/qip/64'
+    expect(page).to have_content('指標群: 呼吸器系')
+
+    # 編集ページへ
+    click_link('複製')
+    find('#project_rofuku').set(true)
+    fill_in('project_rofuku_number', with: '12345')
+    find('#year_2014').set(true)
+    find('#group').set('循環器系')
+    find('#editor').set('変更者1')
+    find('#message').set('テストのために変更しました')
+    click_button('　作　成　')
+
+    # 確認 Modal が出る
+    expect(page).to have_content('レコードの登録が完了しました')
+    expect(page).to have_content('次の定義を登録する')
+    expect(page).to have_content('TOPに戻る')
+
+    # もとの定義書が変更されていない確認
+    visit '/definitions/qip/64'
+    expect(page).to have_content('QIP')
+    expect(page).to have_content('64')
+    expect(page).to have_content('2008')
+    expect(page).to have_content('2010')
+    expect(page).not_to have_content('2014')
+    expect(page).to have_content('呼吸器系')
+    find('#show_change_log').click
+    expect(page).not_to have_content('変更者: 変更者1　 変更メッセージ: テストのために変更しました')
+    expect(page).not_to have_content('アルガトロバン水和物')
+    first('.panel-default').click_link('内容を見る').first
+    expect(page).to have_content('アルガトロバン水和物')
+
+    # 複製した定義書の確認
+    visit '/definitions/rofuku/12345'
+    expect(page).to have_content('労災')
+    expect(page).to have_content('12345')
+    expect(page).to have_content('2008')
+    expect(page).to have_content('2010')
+    expect(page).to have_content('2014')
+    expect(page).to have_content('循環器系')
+    expect(page).to have_content('縦隔生検を実施した')
+    find('#show_change_log').click
+    expect(page).to have_content('変更者: 変更者1　 変更メッセージ: テストのために変更しました')
+    expect(page).not_to have_content('アルガトロバン水和物')
+    first('.panel-default').click_link('内容を見る').first
+    expect(page).to have_content('アルガトロバン水和物')
+  end
+
   scenario 'cannot update definition without editor info', js: true do
     visit '/definitions/qip/64'
     expect(page).to have_content('指標群: 呼吸器系')

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe HomeController, type: :feature do
     # 指標ページ
     expect(page).to have_content('指標群: 呼吸器系')
     expect(page).to have_content('編集')
+    expect(page).to have_content('複製')
     expect(page).to have_content('pdf')
     expect(page).not_to have_content('アルガトロバン水和物')
     first('.panel-default').click_link('内容を見る').first


### PR DESCRIPTION
* 指標の複製機能追加
    * `プロジェクト名`と`プロジェクト番号`と`変更履歴`を除いたデータをデフォルト値として、指標新規作成ページに遷移する
    * 各指標の表示ページから、[複製] ボタンを押下することでこの機能が使用できる

* `Definition.all.size` → `Definition.count` で高速化

ref #80 