### PR TITLE
add capistrano to automatic deploy after CircleCI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'
 gem 'sass-rails', '~> 5.0'
@@ -58,16 +57,17 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+
+  # Use Capistrano for deployment
+  gem 'capistrano-rails'
+  gem 'capistrano-rbenv'
+  gem 'capistrano-bundler'
+  gem 'capistrano3-unicorn'
+  gem 'net-ssh'
 end
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-
-# Use unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,21 @@ GEM
     bson (3.2.6)
     builder (3.2.2)
     byebug (6.0.2)
+    capistrano (3.4.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (~> 1.3)
+    capistrano-bundler (1.1.4)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
+    capistrano-rails (1.1.5)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
+    capistrano-rbenv (2.0.3)
+      capistrano (~> 3.1)
+      sshkit (~> 1.3)
+    capistrano3-unicorn (0.2.1)
+      capistrano (~> 3.1, >= 3.1.0)
     capybara (2.5.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -64,6 +79,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
+    colorize (0.7.7)
     connection_pool (2.2.0)
     coveralls (0.8.3)
       json (~> 1.8)
@@ -120,6 +136,9 @@ GEM
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
     multi_json (1.11.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.0.1)
     netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -208,6 +227,10 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sshkit (1.7.1)
+      colorize (>= 0.7.0)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     therubyracer (0.12.2)
@@ -251,6 +274,10 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   byebug
+  capistrano-bundler
+  capistrano-rails
+  capistrano-rbenv
+  capistrano3-unicorn
   capybara
   capybara-webkit
   coffee-rails (~> 4.1.0)
@@ -262,6 +289,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   mongoid (~> 4.0.0)
+  net-ssh
   poltergeist
   rails (= 4.2.4)
   rails-api

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  timezone: Asia/Tokyo
+dependencies:
+  pre:
+    - cp config/ssh_config ~/.ssh/config
+    - chmod 600 ~/.ssh/config
+deployment:
+  production:
+    branch: release
+    commands:
+      - bash ./scripts/deploy.sh production release

--- a/config/deploy/production_circleci.rb
+++ b/config/deploy/production_circleci.rb
@@ -1,0 +1,9 @@
+set :stage, :production
+set :rails_env, 'production'
+set :deploy_to, "/opt/rails/#{fetch(:application)}"
+set :config_path, 'config'
+set :unicorn_pid, -> { File.join(shared_path, 'tmp', 'pids', 'unicorn.pid') }
+set :unicorn_config_path, 'config/unicorn.rb'
+set :unicorn_rack_env, "#{fetch(:rails_env)}"
+set :unicorn_restart_sleep_time, 3
+server 'qidb', roles: %w(web app)

--- a/config/ssh_config
+++ b/config/ssh_config
@@ -1,0 +1,4 @@
+Host qidb
+  User rails
+  HostName 160.16.76.138
+  IdentitiesOnly yes

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,44 @@
+ENV['RAILS_ENV'] || 'production'
+
+app_path = "/opt/rails/QIDB"
+app_shared_path = "#{app_path}/shared"
+
+# number of workers
+worker_processes 4
+
+# 実態は symlink。
+# SIGUSR2 を送った時にこの symlink に対して
+# Unicorn のインスタンスが立ち上がる
+working_directory "#{app_path}/current/"
+
+# socket or port
+listen '/tmp/unicorn.sock'
+
+# log
+stderr_path File.expand_path('log/unicorn.log', ENV['RAILS_ROOT'])
+stdout_path File.expand_path('log/unicorn.log', ENV['RAILS_ROOT'])
+
+pid "#{app_shared_path}/tmp/pids/unicorn.pid"
+
+before_exec do
+  ENV['BUNDLE_GEMFILE'] = "#{app_path}/current/Gemfile"
+end
+
+# prevent downtime
+preload_app true
+timeout 300
+
+before_fork do |server, _|
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.connection.disconnect!
+
+  old_pid = "#{server.config[:pid]}.oldbin"
+  unless old_pid == server.pid
+    begin
+      Process.kill('QUIT', File.read(old_pid).to_i)
+    end
+  end
+end
+
+after_fork do
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
## 自動デプロイの説明
* サーバーにデプロイされるのは `release` ブランチのみ。
* CircleCIで `release` ブランチの rspec が通れば、自動的にサーバーにデプロイされる。

## release ブランチとは
機能開発をしたブランチはプルリクエストでコードレビューが終わった後に `master` ブランチに merge される。
開発した機能をサーバーにデプロイしたい場合には、
```
# master ブランチの最新版を pull
$ git pull origin master

# release ブランチに切り替え
$ git checkout release

# release ブランチを master ブランチの最新版にする
$ git merge master

# release ブランチを GitHub に push
$ git push origin release
```
とすることで、push 後に Circle CI が走って、テストが通ればアプリケーションがサーバーにデプロイされる。