### PR TITLE
テーブル表示時に index でソートする

### DIFF
--- a/app/controllers/definitions_controller.rb
+++ b/app/controllers/definitions_controller.rb
@@ -12,11 +12,11 @@ class DefinitionsController < ApplicationController
   end
 
   def show_table
-    @definitions = Definition.active
+    @definitions = Definition.active.sort_by { |e| e['index'] }
   end
 
   def show_table_en
-    @definitions = Definition.active
+    @definitions = Definition.active.sort_by { |e| e['index'] }
   end
 
   def new


### PR DESCRIPTION
テーブル表示時に `index` の昇順でソートした。
`index` の値は `xx_xx` (`x` は 0~9 の数値)の形で入っているため、単純な文字列比較でソート可能。
