### PR TITLE
T131 テキストエリアでの改行有効化

### DIFF
--- a/app/views/definitions/show.html.erb
+++ b/app/views/definitions/show.html.erb
@@ -39,7 +39,7 @@
         <label>指標の定義算出方法</label>:</p>
         <label>分母の定義</label>:</p>
         <% @definition.definitions['def_denom'].each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default" id="def_denom_<%= key %>_data">
@@ -84,7 +84,7 @@
 
         <label>分子の定義</label>:</p>
         <% @definition.definitions['def_numer'].each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default" id="def_numer_<%= key %>_data">
@@ -129,7 +129,7 @@
         <label>薬剤一覧の出力</label>: <%= @definition.drug_output %></p>
         <label>リスク調整因子の条件</label>:</p>
         <% @definition.def_risks.each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default">
@@ -176,7 +176,7 @@
 
         <label>測定上の限界・解釈上の注意</label>:</p>
         <% @definition.annotation.each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default">
@@ -221,7 +221,7 @@
 
         <label>参考値</label>:</p>
         <% @definition.standard_value.each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default">
@@ -269,7 +269,7 @@
 
         <label>参考資料</label>:</p>
         <% @definition.references.each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default">

--- a/app/views/definitions/show.pdf.erb
+++ b/app/views/definitions/show.pdf.erb
@@ -28,7 +28,7 @@
     <label>指標の定義算出方法</label>:</p>
     <label>分母の定義</label>:</p>
     <% @definition.definitions['def_denom'].each do |key,value| %>
-      <%= key %>：<%= value['explanation'] %></p>
+      <%= key %>：<%= simple_format(value['explanation']) %></p>
       <% if value['data'].present? %>
         <div class="col-lg-12">
           <div class="panel panel-default">
@@ -64,7 +64,7 @@
 
     <label>分子の定義</label>:</p>
     <% @definition.definitions['def_numer'].each do |key,value| %>
-      <%= key %>：<%= value['explanation'] %></p>
+      <%= key %>：<%= simple_format(value['explanation']) %></p>
       <% if value['data'].present? %>
         <div class="col-lg-12">
           <div class="panel panel-default">
@@ -100,7 +100,7 @@
     <label>薬剤一覧の出力</label>: <%= @definition.drug_output %></p>
     <label>リスク調整因子の条件</label>:</p>
     <% @definition.def_risks.each do |key,value| %>
-      <%= key %>：<%= value['explanation'] %></p>
+      <%= key %>：<%= simple_format(value['explanation']) %></p>
       <% if value['data'].present? %>
         <div class="col-lg-12">
           <div class="panel panel-default">
@@ -136,7 +136,7 @@
     <label>指標の算出方法(単位)</label>: <%= @definition['method']['unit'] %></p>
     <label>測定上の限界・解釈上の注意</label>:</p>
     <% @definition.annotation.each do |key,value| %>
-      <%= key %>：<%= value['explanation'] %></p>
+      <%= key %>：<%= simple_format(value['explanation']) %></p>
       <% if value['data'].present? %>
         <div class="col-lg-12">
           <div class="panel panel-default">
@@ -171,7 +171,7 @@
     <% end %>
     <label>参考値</label>:</p>
     <% @definition.standard_value.each do |key,value| %>
-      <%= key %>：<%= value['explanation'] %></p>
+      <%= key %>：<%= simple_format(value['explanation']) %></p>
       <% if value['data'].present? %>
         <div class="col-lg-12">
           <div class="panel panel-default">
@@ -205,7 +205,7 @@
     <% end %>
     <label>参考資料</label>:</p>
     <% @definition.references.each do |key,value| %>
-      <%= key %>：<%= value['explanation'] %></p>
+      <%= key %>：<%= simple_format(value['explanation']) %></p>
       <% if value['data'].present? %>
         <div class="col-lg-12">
           <div class="panel panel-default">

--- a/app/views/definitions/show_en.html.erb
+++ b/app/views/definitions/show_en.html.erb
@@ -48,7 +48,7 @@
         <label>指標の定義算出方法</label>:</p>
         <label>分母の定義</label>:</p>
         <% @definition.definitions['def_denom'].each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default" id="def_denom_<%= key %>_data">
@@ -93,7 +93,7 @@
 
         <label>分子の定義</label>:</p>
         <% @definition.definitions['def_numer'].each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default" id="def_numer_<%= key %>_data">
@@ -138,7 +138,7 @@
         <label>薬剤一覧の出力</label>: <%= @definition.drug_output %></p>
         <label>リスク調整因子の条件</label>:</p>
         <% @definition.def_risks.each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default">
@@ -185,7 +185,7 @@
 
         <label>測定上の限界・解釈上の注意</label>:</p>
         <% @definition.annotation.each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default">
@@ -230,7 +230,7 @@
 
         <label>参考値</label>:</p>
         <% @definition.standard_value.each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default">
@@ -278,7 +278,7 @@
 
         <label>参考資料</label>:</p>
         <% @definition.references.each do |key,value| %>
-          <%= key %>：<%= value['explanation'] %></p>
+          <%= key %>：<%= simple_format(value['explanation']) %></p>
           <% if value['data'].present? %>
             <div class="col-lg-12">
               <div class="panel panel-default">


### PR DESCRIPTION
分母や分子の定義などで改行が有効になるようにしました。確認お願いします。
今度は勝手にmergeしてしまわないように下手に触らないでおきます。