### PR TITLE
fix table header overlapping in pdf

### DIFF
--- a/app/assets/stylesheets/pdf.css
+++ b/app/assets/stylesheets/pdf.css
@@ -1,0 +1,3 @@
+thread { display: table-header-group }
+tfoot { display: table-row-group }
+tr { page-break-inside: avoid }

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>QIDB</title>
-  <%= wicked_pdf_stylesheet_link_tag    'application', media: 'all'%>
+  <%= wicked_pdf_stylesheet_link_tag    'application', 'pdf', media: 'all'%>
   <%= wicked_pdf_javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
- バグの原因
参考リンク: https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2367#issuecomment-446473600

- 注意点
https://qiita.com/hogehoge1234/items/f9775573458304eedaf5